### PR TITLE
sepolicy: Also allow vendor_file text relocations

### DIFF
--- a/public/domain.te
+++ b/public/domain.te
@@ -818,6 +818,7 @@ ifelse(target_needs_platform_text_relocations, `true',
     file_type
     -system_file
     -system_data_file
+    -vendor_file
     -apk_data_file
     -app_data_file
     -asec_public_file


### PR DESCRIPTION
 * Some devices(huashan in this case) may need execmod permissions over files
    located in /system/vendor or /vendor, therefore allow
    the vendor_file label to be used for execmod rules too

Change-Id: Ic53656b82d4968ddd1486e11c7bb1b82b3baad50